### PR TITLE
release: 2.2.5

### DIFF
--- a/src/main/kotlin/org/gitanimals/core/redis/TraceableMessageListener.kt
+++ b/src/main/kotlin/org/gitanimals/core/redis/TraceableMessageListener.kt
@@ -25,7 +25,6 @@ abstract class TraceableMessageListener(
                 object : TypeReference<Map<String, String>>() {},
             )
 
-            logger.info("[$listenerName] request: $request")
 
             runCatching {
                 request["traceId"] as String
@@ -38,6 +37,7 @@ abstract class TraceableMessageListener(
                 MDC.put(MDCFilter.USER_ID, it)
             }
 
+            logger.info("[$listenerName] request: $request")
             onMessage(message)
         }.onFailure {
             logger.error("Fail to listen message: $message, error: $it", it)


### PR DESCRIPTION
- TraceableMessageListener에 traceId 가 남지 않는 버그를 수정한다